### PR TITLE
Fix/19 Tabs block re-registered successfully

### DIFF
--- a/includes/blocks/block-editor/tabs-item/edit.js
+++ b/includes/blocks/block-editor/tabs-item/edit.js
@@ -3,6 +3,7 @@
  */
 /* eslint-disable import/no-extraneous-dependencies */
 import { __ } from '@wordpress/i18n';
+import { InnerBlocks, RichText } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
@@ -11,6 +12,11 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies
  */
 import { editPropsShape } from './props-shape';
+import createFilterableComponent from '../../utils/createFilterableComponent';
+import CustomBlockAppender from '../../components/custom-block-appender';
+
+const FilterableTabsItemHeader = createFilterableComponent('tenup.tabsItem.header');
+const FilterableTabsItemFooter = createFilterableComponent('tenup.tabsItem.footer');
 
 const TabsItemEdit = (props) => {
 	const {

--- a/includes/blocks/block-editor/tabs-item/save.js
+++ b/includes/blocks/block-editor/tabs-item/save.js
@@ -1,6 +1,7 @@
 /**
  * Wordpress dependencies
  */
+import { InnerBlocks } from '@wordpress/block-editor';
 
 const TabsItemSave = () => <InnerBlocks.Content />;
 export default TabsItemSave;

--- a/includes/blocks/block-editor/tabs/edit.js
+++ b/includes/blocks/block-editor/tabs/edit.js
@@ -9,17 +9,23 @@ import classnames from 'classnames';
 /* eslint-disable import/no-extraneous-dependencies */
 import { createBlock } from '@wordpress/blocks';
 import { compose, ifCondition } from '@wordpress/compose';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, Fragment } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { Button, PanelBody, ToggleControl, NavigableMenu } from '@wordpress/components';
+import { InnerBlocks, InspectorControls, RichText } from '@wordpress/block-editor';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import createFilterableComponent from '../../utils/createFilterableComponent';
 import { editPropsShape } from './props-shape';
 
 import './editor.css';
+
+const FilterableTabsHeader = createFilterableComponent('tenup.tabs.header');
+const FilterableTabsFooter = createFilterableComponent('tenup.tabs.footer');
 
 const TabsEdit = (props) => {
 	const {

--- a/includes/blocks/block-editor/tabs/save.js
+++ b/includes/blocks/block-editor/tabs/save.js
@@ -1,6 +1,7 @@
 /**
  * Wordpress dependencies
  */
+import { InnerBlocks } from '@wordpress/block-editor';
 
 const TabsSave = () => <InnerBlocks.Content />;
 export default TabsSave;

--- a/includes/blocks/components/custom-block-appender/index.js
+++ b/includes/blocks/components/custom-block-appender/index.js
@@ -6,6 +6,10 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Fragment } from '@wordpress/element';
+import { Inserter } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
 
 /**
  * CustomBlockAppender.


### PR DESCRIPTION
All the required components are re-imported to the required files in order to make the tabs block work properly.

Closes #19

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

