### PR TITLE
fix/13 error resolved by removing unnecessary JS load

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -197,25 +197,6 @@ function scripts() {
 		PUBLISHER_MEDIA_KIT_VERSION,
 		true
 	);
-
-	/*$tabs_dep = require_once PUBLISHER_MEDIA_KIT_PATH . 'dist/blocks/tabs-block/editor.asset.php';
-	wp_enqueue_script(
-		'publisher_media_kit_tabs_frontend',
-		PUBLISHER_MEDIA_KIT_URL . 'dist/blocks/tabs-block/editor.js',
-		[ 'wp-blocks'],// $tabs_dep['dependencies'],
-		$tabs_dep['version'],
-		true
-	);*/
-
-	$tabs_item_dep = require_once PUBLISHER_MEDIA_KIT_PATH . 'dist/blocks/tabs-item-block/editor.asset.php';
-	wp_enqueue_script(
-		'publisher_media_kit_tabs_item_frontend',
-		PUBLISHER_MEDIA_KIT_URL . 'dist/blocks/tabs-item-block/editor.js',
-		$tabs_item_dep['dependencies'],
-		$tabs_item_dep['version'],
-		true
-	);
-
 }
 
 /**


### PR DESCRIPTION
closes #13.

Removed enqueueing unnecessary JS on the front side fixes the `wp is not defined` issue.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

