### PR TITLE
Synced tabs block with Block Library Release 1.0.0

### DIFF
--- a/includes/blocks/block-editor/tabs-item/edit.js
+++ b/includes/blocks/block-editor/tabs-item/edit.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 /**
  * Wordpress dependencies
  */

--- a/includes/blocks/block-editor/tabs-item/markup.php
+++ b/includes/blocks/block-editor/tabs-item/markup.php
@@ -5,7 +5,12 @@
  * @package PublisherMediaKit\Blocks
  */
 
+$class_name = ( ! empty( $attributes['className'] ) ) ? $attributes['className'] : '';
+
+if ( empty( $attributes['header'] ) ) {
+	return;
+}
 ?>
-<div class="tab-content" id="tab-item-<?php echo esc_attr( sanitize_title_with_dashes( $attributes['header'] ) ); ?>" role="tabpanel">
+<div class="tab-content <?php echo esc_attr( $class_name ); ?>" id="tab-item-<?php echo esc_attr( sanitize_title_with_dashes( $attributes['header'] ) ); ?>" role="tabpanel">
 	<?php echo wp_kses_post( $content ); ?>
 </div>

--- a/includes/blocks/block-editor/tabs-item/register.js
+++ b/includes/blocks/block-editor/tabs-item/register.js
@@ -6,7 +6,7 @@
  * Internal dependencies
  */
 import { registerBlock } from '../../utils/register-block';
-import tabsItem from './index';
+import tabsItem from '.';
 
 // Register the block - wp.domReady is required for core filters to work with this custom block. See - https://github.com/WordPress/gutenberg/issues/9757
 wp.domReady(function () {

--- a/includes/blocks/block-editor/tabs/block.json
+++ b/includes/blocks/block-editor/tabs/block.json
@@ -47,9 +47,9 @@
 			"type": "boolean",
 			"default": false
 		},
-    "tabsTitle": {
-      "type": "string"
-    }
+		"tabsTitle": {
+		  "type": "string"
+		}
   },
   "supports": {
     "html": false

--- a/includes/blocks/block-editor/tabs/edit.js
+++ b/includes/blocks/block-editor/tabs/edit.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 /**
  * External dependencies
  */
@@ -104,6 +105,7 @@ const TabsEdit = (props) => {
 	};
 
 	const DisplayTabPanel = () => {
+		// eslint-disable-next-line react/prop-types
 		const tabPanels = innerBlocks.map((innerBlock) => {
 			const { attributes, clientId } = innerBlock;
 			const { header } = attributes;
@@ -135,6 +137,7 @@ const TabsEdit = (props) => {
 		 * Hacky solution to positioning the tab header in the correct place
 		 */
 		useEffect(() => {
+			// eslint-disable-next-line react/prop-types
 			innerBlocks.forEach((innerBlock) => {
 				const tabHeader = document.querySelector(
 					`.tab-header[data-tab-block="${innerBlock.clientId}"]`,
@@ -186,6 +189,7 @@ const TabsEdit = (props) => {
 							icon="plus"
 							label={__('Add New Tab', 'publisher-media-kit')}
 							onClick={() => {
+							// eslint-disable-next-line react/prop-types
 								const created = createBlock(
 									'tenup/tabs-item',
 									{

--- a/includes/blocks/block-editor/tabs/editor.css
+++ b/includes/blocks/block-editor/tabs/editor.css
@@ -3,10 +3,13 @@
 :root {
 	--c-appender-button-bg: #000;
 	--c-white: #fff;
+	--c-gray: #777;
 	--c-light-grey: #d3d3d3;
 	--c-placeholder-text: #707070;
 	--tab-item-width: 200px;
 	--tab-item-height: 60px;
+	--tenup-tabs-rich-text-color: #1e1e1e;
+	--tenup-tabs-untitled-tab-color: #6c6c6c;
 }
 
 .wp-block[data-type="tenup/tabs"] {
@@ -26,6 +29,8 @@
 			background-color: var(--c-white);
 			box-sizing: border-box;
 			display: flex;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			font-size: 13px;
 			height: calc(var(--tab-item-height) - 2px);
 			left: 0;
 			padding: 6px 12px;
@@ -106,6 +111,7 @@
 	}
 
 	& .tab-item {
+		border: 1px solid var(--c-gray);
 		display: inline-block;
 		height: var(--tab-item-height);
 		text-align: center;
@@ -135,6 +141,14 @@
 			align-items: center;
 			display: flex;
 			font-weight: 500;
+
+			&:hover {
+				color: var(--tenup-tabs-rich-text-color);
+			}
+		}
+
+		&.untitled {
+			color: var(--tenup-tabs-untitled-tab-color);
 		}
 	}
 
@@ -150,6 +164,11 @@
 			flex-direction: column;
 			white-space: normal;
 
+			& .components-tab-panel__tabs-item.is-active {
+				border-bottom-color: var(--c-gray);
+				border-right-color: var(--c-white);
+			}
+
 			& .add-tab-button {
 				display: block;
 				margin-left: 0;
@@ -162,6 +181,17 @@
 
 		& .untitled {
 			color: var(--c-placeholder-text);
+		}
+	}
+
+	&.components-tab-panel__tabs-item-is-editing .components-tab-panel__tabs {
+
+		& > :not(.is-active) {
+			border-bottom-color: var(--c-gray) !important;
+		}
+
+		& .is-active {
+			border-bottom-color: var(--c-white) !important;
 		}
 	}
 }

--- a/includes/blocks/block-editor/tabs/markup.php
+++ b/includes/blocks/block-editor/tabs/markup.php
@@ -6,8 +6,9 @@
  */
 
 $layout = ! empty( $attributes['tabVertical'] ) ? 'tabs-vertical' : '';
+$class_name = ( ! empty( $attributes['className'] ) ) ? $attributes['className'] : '';
 ?>
-<div class="tabs <?php echo esc_attr( $layout ); ?>">
+<div class="tabs <?php echo esc_attr( $layout ); ?> <?php echo esc_attr( $class_name ); ?>">
 	<!-- Tabs Placeholder -->
 	<div class="tab-group">
 		<?php echo wp_kses_post( $content ); ?>

--- a/includes/blocks/block-editor/tabs/register.js
+++ b/includes/blocks/block-editor/tabs/register.js
@@ -6,7 +6,7 @@
  * Internal dependencies
  */
 import { registerBlock } from '../../utils/register-block';
-import tabs from './index';
+import tabs from '.';
 
 // Register the block
 // wp.domReady is required for core filters to work with this custom block. See - https://github.com/WordPress/gutenberg/issues/9757

--- a/includes/blocks/components/custom-block-appender/index.js
+++ b/includes/blocks/components/custom-block-appender/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 /**
  * External dependencies
  */
@@ -17,11 +18,11 @@ import { Button } from '@wordpress/components';
  * Provide a Button component to trigger the inserter.
  * Any undocumented props are spread onto the Button component.
  *
- * @param {object} props              All props sent to this component.
+ * @param {Object} props              All props sent to this component.
  * @param {string} props.rootClientId Client ID of the block where this is being used.
  * @param {string} [props.buttonText] Text to display in the Button.
  * @param {string} [props.icon]       The icon to use.
- * @returns {Function} The component.
+ * @return {Function} The component.
  */
 const CustomBlockAppender = ({ rootClientId, buttonText, icon, ...buttonProps }) => {
 	return (


### PR DESCRIPTION
### Description of the Change

The tabs block is updated with the changes seen after [Official 10up Block Library Release (1.0.0)](https://internal.10up.com/blog/2021/11/12/official-10up-block-library-release/).

### Benefits

Keep the blocks updated with the 10up Block Library.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
