### PR TITLE
Fix/65 The Orientation Options are removed

### DIFF
--- a/assets/js/frontend/frontend.js
+++ b/assets/js/frontend/frontend.js
@@ -1,9 +1,7 @@
 // import foo from './components/bar';
 import Tabs from '@10up/component-tabs';
 
-const orientation = document.querySelector('.tabs-vertical');
-
 // eslint-disable-next-line no-new
 new Tabs('.tabs', {
-	orientation: orientation ? 'vertical' : 'horizontal',
+	orientation: 'horizontal',
 });

--- a/includes/blocks/block-editor/tabs-item/edit.js
+++ b/includes/blocks/block-editor/tabs-item/edit.js
@@ -25,7 +25,6 @@ const TabsItemEdit = (props) => {
 		hasSelectedInnerBlock,
 		setAttributes,
 		clientId,
-		orientation,
 		position,
 		name,
 		attributes: { header },
@@ -39,7 +38,7 @@ const TabsItemEdit = (props) => {
 			<div className={classes}>
 				<div
 					data-tab-block={clientId}
-					className={`orientation-${orientation} position-${position}`}
+					className={`orientation-horizontal position-${position}`}
 				>
 					{/* The reason we don't have the RichText field in the parent block is so that when you are editing tab header text you are selecting
 					the child block. */}
@@ -97,7 +96,6 @@ export default compose(
 
 		return {
 			position,
-			orientation: parentBlock.attributes.tabVertical ? 'vertical' : 'horizontal',
 			hasSelectedInnerBlock,
 		};
 	}),

--- a/includes/blocks/block-editor/tabs/block.json
+++ b/includes/blocks/block-editor/tabs/block.json
@@ -43,10 +43,6 @@
 		]
 	},
 	"attributes": {
-		"tabVertical": {
-			"type": "boolean",
-			"default": false
-		},
 		"tabsTitle": {
 		  "type": "string"
 		}

--- a/includes/blocks/block-editor/tabs/edit.js
+++ b/includes/blocks/block-editor/tabs/edit.js
@@ -30,7 +30,7 @@ const FilterableTabsFooter = createFilterableComponent('tenup.tabs.footer');
 
 const TabsEdit = (props) => {
 	const {
-		attributes: { tabVertical, tabsTitle },
+		attributes: { tabsTitle },
 		setAttributes,
 		isSelected,
 		className,
@@ -42,7 +42,6 @@ const TabsEdit = (props) => {
 		activeClass = 'is-active',
 	} = props;
 	const { innerBlocks } = block;
-	const orientation = tabVertical ? 'vertical' : 'horizontal';
 	const [tabCount, setTabCount] = useState(innerBlocks.length);
 	const [editTab, setEditTab] = useState('');
 
@@ -149,18 +148,9 @@ const TabsEdit = (props) => {
 				const positionInfo = tabHeaderButton.getBoundingClientRect();
 
 				if (tabHeader && tabHeaderButton) {
-					if (orientation === 'horizontal') {
-						// console.log(`${header} - Move to ${tabHeaderButton.offsetLeft}`);
-						tabHeader.style.left = `${tabHeaderButton.offsetLeft}px`;
-						tabHeader.style.width = `${positionInfo.width - 2}px`;
-						tabHeader.style.top = '-58px';
-
-						// debugger;
-					} else {
-						tabHeader.style.top = `${tabHeaderButton.offsetTop}px`;
-						tabHeader.style.left = '-118px';
-						tabHeader.style.width = '120px';
-					}
+					tabHeader.style.left = `${tabHeaderButton.offsetLeft}px`;
+					tabHeader.style.width = `${positionInfo.width - 2}px`;
+					tabHeader.style.top = '-58px';
 				}
 			});
 		});
@@ -180,7 +170,7 @@ const TabsEdit = (props) => {
 							return false;
 						}}
 						role="tablist"
-						orientation={orientation}
+						orientation="horizontal"
 						className="components-tab-panel__tabs tab-list"
 					>
 						{tabPanels}
@@ -213,34 +203,14 @@ const TabsEdit = (props) => {
 		);
 	};
 
-	const orientationOptions = () => {
-		return (
-			<InspectorControls>
-				{applyFilters('tenup.tabs.showOrientationOption', true, clientId) ? (
-					<PanelBody title={__('Orientation Options', 'publisher-media-kit')}>
-						<ToggleControl
-							label={__('Vertical Layout', 'publisher-media-kit')}
-							checked={tabVertical}
-							onChange={() => setAttributes({ tabVertical: !tabVertical })}
-						/>
-					</PanelBody>
-				) : (
-					''
-				)}
-			</InspectorControls>
-		);
-	};
-
 	return (
 		<>
-			{orientationOptions()}
-
-			<div className={`${className} ${classes} tabs-${orientation}`}>
+			<div className={`${className} ${classes} tabs-horizontal`}>
 				<FilterableTabsHeader blockProps={props} />
 				{DisplayTabPanel()}
 				<div className="tab-group">
 					<InnerBlocks
-						orientation={orientation}
+						orientation="horizontal"
 						allowedBlocks={['tenup/tabs-item']}
 						// eslint-disable-next-line prettier/prettier
 						template={[['tenup/tabs-item', { header: '' }, [[ 'core/paragraph', {} ]]]]}

--- a/includes/blocks/block-editor/tabs/editor.css
+++ b/includes/blocks/block-editor/tabs/editor.css
@@ -38,11 +38,6 @@
 			text-align: center;
 			top: calc(calc(-1 * var(--tab-item-height)) + 2px);
 
-			&.orientation-vertical {
-				left: calc(calc(-1 * var(--tab-item-width)) + 2px);
-				top: 0;
-			}
-
 			& .rich-text {
 				height: 100%;
 				line-height: 1.2;
@@ -158,22 +153,6 @@
 	}
 
 	& .components-tab-panel__tabs {
-
-		&[aria-orientation="vertical"] {
-			display: flex;
-			flex-direction: column;
-			white-space: normal;
-
-			& .components-tab-panel__tabs-item.is-active {
-				border-bottom-color: var(--c-gray);
-				border-right-color: var(--c-white);
-			}
-
-			& .add-tab-button {
-				display: block;
-				margin-left: 0;
-			}
-		}
 
 		& .components-text-control__input {
 			margin-left: 5px;

--- a/includes/blocks/block-editor/tabs/markup.php
+++ b/includes/blocks/block-editor/tabs/markup.php
@@ -5,10 +5,9 @@
  * @package PublisherMediaKit\Blocks
  */
 
-$layout = ! empty( $attributes['tabVertical'] ) ? 'tabs-vertical' : '';
 $class_name = ( ! empty( $attributes['className'] ) ) ? $attributes['className'] : '';
 ?>
-<div class="tabs <?php echo esc_attr( $layout ); ?> <?php echo esc_attr( $class_name ); ?>">
+<div class="tabs horizontal <?php echo esc_attr( $class_name ); ?>">
 	<!-- Tabs Placeholder -->
 	<div class="tab-group">
 		<?php echo wp_kses_post( $content ); ?>

--- a/includes/blocks/block-editor/tabs/props-shape.js
+++ b/includes/blocks/block-editor/tabs/props-shape.js
@@ -4,9 +4,6 @@
 import PropTypes from 'prop-types';
 
 export const propsShape = {
-	attributes: PropTypes.shape({
-		tabVertical: PropTypes.boolean,
-	}).isRequired,
 	clientId: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
### Description of the Change

The Orientation Options in the Tabs block are removed. Default set to `horizontal` layout.

Closes #65

### Verification Process

1. Build the project files using `npm run build`.
2. Edit the 'Media Kit' page.
3. Go to the 'Our Rates' tabs section.
4. The 'Orientation Options' should not be available.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Removed - The Orientation Options.