### PR TITLE
Compatible tabs with the upstream version `1.0.2`

### DIFF
--- a/includes/blocks/block-editor/tabs/edit.js
+++ b/includes/blocks/block-editor/tabs/edit.js
@@ -14,6 +14,7 @@ import { useState, useEffect, Fragment } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Button, NavigableMenu } from '@wordpress/components';
 import { InnerBlocks, RichText } from '@wordpress/block-editor';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -125,7 +126,7 @@ const TabsEdit = (props) => {
 							document.getElementById(`block-${clientId}`).setAttribute('data-is-tab-header-editing', 1);
 						}}
 					>
-						{header || __('Tab Header', 'publisher-media-kit')}
+						{decodeEntities(header) || __('Tab Header', 'publisher-media-kit')}
 					</Button>
 				</Fragment>
 			);


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Updates the tabs block as per the new upstream block releases.
https://github.com/10up/block-library/releases/tag/1.0.2

<!-- Enter any applicable Issues here. Example: -->
Closes #80.

### Verification Process

Test the `tabs` block if it works fine after the release updates.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Changed - Update tabs block as per the upstream release `1.0.2`.

### Credits

Props @faisal-alvi @jeffpaul 
