### PR TITLE
Release/1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
+## [1.2.1] - 2022-07-19
+
+### Changed
+- Updated the `CONTRIBUTING.md` file (props [@faisal-alvi](https://github.com/faisal-alvi), [@jeffpaul](https://github.com/jeffpaul) via [#89](https://github.com/10up/publisher-media-kit/pull/89))
+
+### Fixed
+- Bring back the `/assets/images` directory to avoid broken images (props [@dkotter](https://github.com/dkotter), [@kmwilkerson](https://github.com/kmwilkerson), [@faisal-alvi](https://github.com/faisal-alvi) via [#91](https://github.com/10up/publisher-media-kit/pull/91))
+
 ## [1.2.0] - 2022-06-27
 ### Added
-- Dependency security scanning. (props [@jeffpaul.](https://github.com/jeffpaul), [@faisal-alvi](https://github.com/faisal-alvi) via [#84](https://github.com/10up/publisher-media-kit/pull/84))
+- Dependency security scanning. (props [@jeffpaul](https://github.com/jeffpaul), [@faisal-alvi](https://github.com/faisal-alvi) via [#84](https://github.com/10up/publisher-media-kit/pull/84))
 
 ### Changed
 - Bump WordPress "tested up to" version 6.0. (props [@ajmaurya99](https://github.com/ajmaurya99), [@faisal-alvi](https://github.com/faisal-alvi), [@vikrampm1](https://github.com/vikrampm1) via [#83](https://github.com/10up/publisher-media-kit/pull/83))
@@ -45,6 +53,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 - Initial private plugin release 🎉
 
 [Unreleased]: https://github.com/10up/publisher-media-kit/compare/trunk...develop
+[1.2.1]: https://github.com/10up/publisher-media-kit/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/10up/publisher-media-kit/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/10up/publisher-media-kit/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/10up/publisher-media-kit/compare/0.9.0...1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "publisher-media-kit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publisher-media-kit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "scripts": {
     "start": "10up-toolkit start",
     "watch": "10up-toolkit watch",

--- a/publisher-media-kit.php
+++ b/publisher-media-kit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Publisher Media Kit
  * Plugin URI:        https://github.com/10up/publisher-media-kit
  * Description:       Pre-configured Media Kit Page using Gutenberg Block Patterns.
- * Version:           1.2.0
+ * Version:           1.2.1
  * Requires at least: 5.5
  * Requires PHP:      7.0
  * Author:            10up
@@ -17,7 +17,7 @@
  */
 
 // Useful global constants.
-define( 'PUBLISHER_MEDIA_KIT_VERSION', '1.2.0' );
+define( 'PUBLISHER_MEDIA_KIT_VERSION', '1.2.1' );
 define( 'PUBLISHER_MEDIA_KIT_URL', plugin_dir_url( __FILE__ ) );
 define( 'PUBLISHER_MEDIA_KIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'PUBLISHER_MEDIA_KIT_BLOCKS_PATH', plugin_dir_path( __FILE__ ) . 'includes/blocks/block-editor/' );

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,10 @@ We require WordPress 5.5 and above as this is when `register_block_pattern_categ
 
 == Changelog ==
 
+= 1.2.1 = 2022-07-19
+* **Changed:** Updated the `CONTRIBUTING.md` file (props [@faisal-alvi](https://github.com/faisal-alvi), [@jeffpaul](https://github.com/jeffpaul) via [#89](https://github.com/10up/publisher-media-kit/pull/89))
+* **Fixed:** Bring back the `/assets/images` directory to avoid broken images (props [@dkotter](https://github.com/dkotter), [@kmwilkerson](https://github.com/kmwilkerson), [@faisal-alvi](https://github.com/faisal-alvi) via [#91](https://github.com/10up/publisher-media-kit/pull/91))
+
 = 1.2.0 = 2022-06-27
 * **Added:** Dependency security scanning. (props [@jeffpaul.](https://github.com/jeffpaul), [@faisal-alvi](https://github.com/faisal-alvi)) via [#84](https://github.com/10up/publisher-media-kit/pull/84))
 * **Changed:** Bump WordPress "tested up to" version 6.0. (props [@ajmaurya99](https://github.com/ajmaurya99), [@faisal-alvi](https://github.com/faisal-alvi), [@vikrampm1](https://github.com/vikrampm1)) via [#83](https://github.com/10up/publisher-media-kit/pull/83))

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      10up, jeffpaul, faisal03
 Tags:              media kit, audience profiles, digital ad specs, ad rates
 Requires at least: 5.5
 Tested up to:      6.0
-Stable tag:        1.2.0
+Stable tag:        1.2.1
 Requires PHP:      7.2
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change

Release and version bump to 1.2.1

Closes #93

### How to test the Change

Verified manually via any IDE and the GitHub Desktop UI