### PR TITLE
Update Support Level from Active to Stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Pre-configured Media Kit Page using Gutenberg Block Patterns.
 
-[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![E2E Tests](https://github.com/10up/publisher-media-kit/actions/workflows/cypress.yml/badge.svg)](https://github.com/10up/publisher-media-kit/actions/workflows/cypress.yml) [![Linting](https://github.com/10up/publisher-media-kit/actions/workflows/lint.yml/badge.svg)](https://github.com/10up/publisher-media-kit/actions/workflows/lint.yml) ![PHPCompatibility](https://github.com/10up/publisher-media-kit/actions/workflows/php-compatibility.yml/badge.svg) [![Release Version](https://img.shields.io/github/release/10up/publisher-media-kit.svg)](https://github.com/10up/publisher-media-kit/releases/latest) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/publisher-media-kit?label=WordPress) [![GPLv2 License](https://img.shields.io/github/license/10up/publisher-media-kit.svg)](https://github.com/10up/publisher-media-kit/blob/develop/LICENSE.md)
+[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![E2E Tests](https://github.com/10up/publisher-media-kit/actions/workflows/cypress.yml/badge.svg)](https://github.com/10up/publisher-media-kit/actions/workflows/cypress.yml) [![Linting](https://github.com/10up/publisher-media-kit/actions/workflows/lint.yml/badge.svg)](https://github.com/10up/publisher-media-kit/actions/workflows/lint.yml) ![PHPCompatibility](https://github.com/10up/publisher-media-kit/actions/workflows/php-compatibility.yml/badge.svg) [![Release Version](https://img.shields.io/github/release/10up/publisher-media-kit.svg)](https://github.com/10up/publisher-media-kit/releases/latest) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/publisher-media-kit?label=WordPress) [![GPLv2 License](https://img.shields.io/github/license/10up/publisher-media-kit.svg)](https://github.com/10up/publisher-media-kit/blob/develop/LICENSE.md)
 
 ## Overview
 
@@ -53,7 +53,7 @@ Click the block inserter (`+` button) in the top left of the block editor, click
 
 ## Support Level
 
-**Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.
+**Stable:** 10up is not planning to develop any new features for this, but will still respond to bug reports and security concerns. We welcome PRs, but any that include new features should be small and easy to integrate and should not include breaking changes. We otherwise intend to keep this tested up to the most recent version of WordPress.
 
 ## Changelog
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR drops the support level from Active to Stable. There's a similar [support forum post on WP.org](https://wordpress.org/support/topic/read-this-before-you-post-62/) that attempts to avoid support issues there and instead push folks to GitHub as well as note that bugs and security issues get priority, PRs for enhancements will be considered, but otherwise we intend to test against major WordPress versions only.

### How to test the Change
n/a

### Changelog Entry
> Changed - Support Level from Active to Stable

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
