### PR TITLE
Fix compatibility with PSR-4 zutoloading of class.

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install Composer dependencies
         if: steps.cache-vendor.outputs.cache-hit != 'true'
-        run: composer install --no-dev
+        run: composer install --no-dev --optimize-autoloader
 
       - name: Build plugin
         run: npm run build

--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -14,6 +14,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cache vendor
+        id: cache-composer
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-vendor
+        with:
+          path: |
+            vendor
+            ~/.composer/cache
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
+
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v3
@@ -32,6 +43,10 @@ jobs:
       - name: Install Node dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm install
+
+      - name: Install Composer dependencies
+        if: steps.cache-vendor.outputs.cache-hit != 'true'
+        run: composer install --no-dev
 
       - name: Build plugin
         run: npm run build

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Install dependencies
       run: npm i
 
+    - name: Install composer dependencies
+      run: composer install --no-dev --optimize-autoloader
+
     - name: Build asset
       run: npm run build
 

--- a/.github/workflows/dotorg-push-deploy.yml
+++ b/.github/workflows/dotorg-push-deploy.yml
@@ -9,10 +9,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Build
+    - name: Install and build NPM
       run: |
         npm install
         npm run build
+    - name: Install and build Composer
+      run: |
+        composer install --no-dev --optimize-autoloader
     - name: WordPress Plugin Deploy
       id: deploy
       uses: 10up/action-wordpress-plugin-deploy@stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,14 @@ The following is a set of guidelines for contributors as well as information and
 
 ## Installation
 
-The following command is required to start contribution. This command will install required dependencies.
+The following commands are required to start contribution. This command will install required dependencies.
 
-### `npm install`
+```sh
+composer install
+npm install
+```
 
-### NPM  Commands
+### NPM commands
 
 * `npm run start` (install dependencies)
 * `npm run watch` (start watch on files)
@@ -20,6 +23,11 @@ The following command is required to start contribution. This command will insta
 * `npm run lint-style` (lint CSS)
 * `npm run test` (run phpunit)
 * `npm run clean-dist` (remove the `dist` folder)
+
+### Composer commands
+
+* `composer run lint` (run PHP code sniffer)
+* `composer run lint-fix` (auto correct fixable PHP coding standards errors)
 
 ## Ways to contribute
 

--- a/includes/classes/blocks/BlockContext/Tabs.php
+++ b/includes/classes/blocks/BlockContext/Tabs.php
@@ -5,7 +5,19 @@
  * @package PublisherMediaKit\Blocks
  */
 
-namespace PublisherMediaKit\Blocks\BlockContext;
+/*
+ * Please not the lowercase B in the blocks portion of the namespace.
+ *
+ * Due to an earlier typo in the blocks folder name (it uses a lower case b),
+ * that part of the namespace is lowercase. This is to avoid breaking existing
+ * code that may be referencing this file directly.
+ *
+ * Namespaces are case insensitive whereas file systems can be case sensitive so
+ * the namespace case was modified to match the folder name.
+ *
+ * @see https://github.com/10up/publisher-media-kit/issues/118
+ */
+namespace PublisherMediaKit\blocks\BlockContext;
 
 /**
  * Block registry

--- a/includes/classes/blocks/BlockContext/Tabs.php
+++ b/includes/classes/blocks/BlockContext/Tabs.php
@@ -6,7 +6,7 @@
  */
 
 /*
- * Please not the lowercase B in the blocks portion of the namespace.
+ * Please note the lowercase B in the blocks portion of the namespace.
  *
  * Due to an earlier typo in the blocks folder name (it uses a lower case b),
  * that part of the namespace is lowercase. This is to avoid breaking existing

--- a/publisher-media-kit.php
+++ b/publisher-media-kit.php
@@ -42,6 +42,7 @@ register_deactivation_hook( __FILE__, '\PublisherMediaKit\Core\deactivate' );
 PublisherMediaKit\Core\setup();
 // Blocks
 PublisherMediaKit\Blocks\setup();
+
 /*
  * Please note the lowercase B in the blocks portion of the namespace.
  *

--- a/publisher-media-kit.php
+++ b/publisher-media-kit.php
@@ -42,5 +42,16 @@ register_deactivation_hook( __FILE__, '\PublisherMediaKit\Core\deactivate' );
 PublisherMediaKit\Core\setup();
 // Blocks
 PublisherMediaKit\Blocks\setup();
-// Block Context
-PublisherMediaKit\Blocks\BlockContext\Tabs::get_instance()->setup();
+/*
+ * Please note the lowercase B in the blocks portion of the namespace.
+ *
+ * Due to an earlier typo in the blocks folder name (it uses a lower case b),
+ * that part of the namespace is lowercase. This is to avoid breaking existing
+ * code that may be referencing this file directly.
+ *
+ * Namespaces are case insensitive whereas file systems can be case sensitive so
+ * the namespace case was modified to match the folder name.
+ *
+ * @see https://github.com/10up/publisher-media-kit/issues/118
+ */
+PublisherMediaKit\blocks\BlockContext\Tabs::get_instance()->setup();

--- a/publisher-media-kit.php
+++ b/publisher-media-kit.php
@@ -33,8 +33,6 @@ if ( file_exists( PUBLISHER_MEDIA_KIT_PATH . 'vendor/autoload.php' ) ) {
 require_once PUBLISHER_MEDIA_KIT_INC . '/core.php';
 // Block Editor
 require_once PUBLISHER_MEDIA_KIT_INC . '/blocks.php';
-// Block Context
-require_once PUBLISHER_MEDIA_KIT_INC . '/classes/blocks/BlockContext/Tabs.php';
 
 // Activation/Deactivation.
 register_activation_hook( __FILE__, '\PublisherMediaKit\Core\activate' );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This recases the namespace used for the `Tabs` class to match the folder structure for compatibility with the autoloader.

@faisal-alvi If you are worried about using the autoloader, feel free to cherry-pick https://github.com/10up/publisher-media-kit/pull/125/commits/8398e9dfb71c7ff0cae5f8d74954d2f464ee94da as the only required commit. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #118

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

I've merged this in to trunk on my fork of the repo, see the [actions running against `trunk`](https://github.com/peterwilsoncc/publisher-media-kit/actions?query=branch%3Atrunk).

I am not sure how to test the wp.org deploy action on my fork. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - PSR-4 Autoloading


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @faisal-alvi 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
