### PR TITLE
Fix/145 Use Node 16 for a Release action

### DIFF
--- a/.github/workflows/dotorg-push-deploy.yml
+++ b/.github/workflows/dotorg-push-deploy.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+    - name: Use nvm
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        check-latest: false
     - name: Install and build NPM
       run: |
         npm install


### PR DESCRIPTION
### Description of the Change
The solution for the linked issue is to downgrade the node version to 16 or below. As they suggested at https://github.com/GoogleChromeLabs/squoosh/issues/1033#issuecomment-1141245720:

> For anyone running into the same problem: Temporarily downgrading to node >=v16 when using @squoosh/lib@0.4.0 is a successful workaround. Thank you 💪

Also they are not planning to support squoosh any more so it is better to downgrade node for now. https://github.com/GoogleChromeLabs/squoosh/issues/1242#issuecomment-1369813258:

> Unfortunately, due to a few people leaving the team, and staffing issues resulting from the current economic climate (ugh), the CLI and libsquoosh packages are no longer actively maintained. I know that sucks, but there simply isn't the time & people to work on this. If anyone from the community wants to fork it, you have my blessing. The [squoosh.app](https://squoosh.app/) web app will continue to be supported and improved.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #145

### How to test the Change
This can be tested upon the next release.

### Changelog Entry
> Fixed - Node engine 18 unsupported for @squoosh/lib causing Release failure

### Credits
Props @faisal-alvi 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
