### PR TITLE
Cypress: Modify how block patterns tab is selected in inserter.

### DIFF
--- a/tests/cypress/integration/pmk-block-patterns.test.js
+++ b/tests/cypress/integration/pmk-block-patterns.test.js
@@ -4,7 +4,7 @@ describe('Check if Media Kit Block Pattern is available for use', () => {
         cy.closeWelcomeGuide();
         cy.get('#post-title-0, h1.editor-post-title__input').click().type('Test Block Pattern');
         cy.get('.edit-post-header-toolbar__inserter-toggle').click();
-        cy.get('.components-tab-panel__tabs button:nth-child(2)').click();
+        cy.get('.components-tab-panel__tabs button').contains( 'Patterns' ).click();
 
         // (add version) If dropdown is available. (After WP 5.?)
         cy.get('body').then(($body) => {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

As the Patterns tab of the block inserter can take a few moments to appear, the selector `.components-tab-panel__tabs button:nth-child(2)` can select the incorrect tab in the inserter (usually media) and cause a false negative in the E2E test runs.

This replaces the E2E tests to use `.contains( 'Patterns' )` to select the tab. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Selection of patterns tab in E2E tests to avoid false failures.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
