### PR TITLE
Fixes an issue with stats cards breaking out of the container

### DIFF
--- a/assets/css/frontend/components/stats.css
+++ b/assets/css/frontend/components/stats.css
@@ -24,7 +24,7 @@ div.wp-block-group.pmk-stats {
 	}
 
 	& .wp-block-columns {
-		flex-wrap: wrap;
+		flex-wrap: wrap !important;
 
 		@media (--wp-medium-max) {
 			justify-content: center;

--- a/assets/css/frontend/components/stats.css
+++ b/assets/css/frontend/components/stats.css
@@ -24,7 +24,7 @@ div.wp-block-group.pmk-stats {
 	}
 
 	& .wp-block-columns {
-		flex-wrap: wrap !important;
+		flex-wrap: wrap !important; /* !important to override columns style WP 6.0+ */
 
 		@media (--wp-medium-max) {
 			justify-content: center;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Fixes an issue introduced by WordPress 6.0 and above on the columns block within the `.pmk-stats` group block, where the columns/column blocks were breaking out of the container.

Sadly this involved using `!important`; there might be a better alternative ...

It seems was first introduced into Gutenberg between December 2022 and January 2023 (https://github.com/WordPress/gutenberg/pull/37436) and then included in WordPress Core with the 6.0 release (https://core.trac.wordpress.org/ticket/55505). I confirmed this by downgrading my local to 5.9.3 (`wp core update --version=5.9.3 --force`) and the fix in this PR wasn't needed. Upgrading to 6.0, the columns broke and the fix was required.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #135 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Follow plugin installation steps: https://wordpress.org/plugins/publisher-media-kit/#installation.
2. Publish the "Media Kit" page.
3. Download and activate the Newspack Base theme.
4. Visit the "Media Kit" page, ensure the Cards under "Audience Profiles" is partly stacked (3 on top, 2 beneath) as per the screenshot in the README.md file.
5. Repeat checks for tablet and smartphones, ensuring the display is appropriate for the screensize (i.e. the Cards should be stacked in rows, 1 per card, etc.).

### Changelog Entry

> Fixed - issue with statistics cards breaking out of container in WordPress 6.0 and above.
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @cameronterry 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly. (N/A)
- [ ] I have added tests to cover my change. (N/A)
- [x] All new and existing tests pass.
