### PR TITLE
Upgrade the `download-artifact` from v3 to v4

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Download build zip
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ github.event.repository.name }}
         path: ${{ github.event.repository.name }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -67,3 +67,13 @@ jobs:
         npx mochawesome-json-to-md -p ./tests/cypress/reports/mochawesome.json -o ./tests/cypress/reports/mochawesome.md
         npx mochawesome-report-generator tests/cypress/reports/mochawesome.json -o tests/cypress/reports/
         cat ./tests/cypress/reports/mochawesome.md >> $GITHUB_STEP_SUMMARY
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: cypress-artifact-publisher-media-kit
+        retention-days: 2
+        path: |
+          ${{ github.workspace }}/tests/cypress/screenshots/
+          ${{ github.workspace }}/tests/cypress/videos/
+          ${{ github.workspace }}/tests/cypress/logs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,8 +112,9 @@
       }
     },
     "@10up/cypress-wp-utils": {
-      "version": "0.2.0",
-      "resolved": "github:10up/cypress-wp-utils#cb14da2cebbfb9e852a1f6ba2177a1b655856e60",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.3.0.tgz",
+      "integrity": "sha512-iMjvca50TerMCY9M9vL0FIE+80ye5YohaQp3XvhgUgQdc4LS51X2fH+lhdb0uRmBTiUQcISazEvWGJxV7DeTbw==",
       "dev": true
     },
     "@10up/eslint-config": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "env:start": "wp-env start",
     "env:stop": "wp-env stop",
     "cypress:open": "cypress open --config-file tests/cypress/config.config.js",
-    "cypress:run": "cypress run --config-file tests/cypress/config.config.js",
+    "cypress:run": "cypress run --config-file tests/cypress/config.config.js --browser chrome",
     "clean-dist": "rm -rf ./dist"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "10up-toolkit": "^4.0.0",
     "stylelint": "^14.0.0",
     "@10up/babel-preset-default": "^1.1.2",
-    "@10up/cypress-wp-utils": "^0.2.0",
+    "@10up/cypress-wp-utils": "^0.3.0",
     "@10up/eslint-config": "^2.4.6",
     "@babel/preset-react": "^7.17.12",
     "@wordpress/env": "^5.2.0",

--- a/tests/cypress/integration/pmk-block-patterns.test.js
+++ b/tests/cypress/integration/pmk-block-patterns.test.js
@@ -3,8 +3,8 @@ describe('Check if Media Kit Block Pattern is available for use', () => {
         cy.visitAdminPage('post-new.php');
         cy.closeWelcomeGuide();
         cy.get('#post-title-0, h1.editor-post-title__input').click( { force: true } ).type('Test Block Pattern');
-        cy.get('.edit-post-header-toolbar__inserter-toggle').click();
-        cy.get('.components-tab-panel__tabs button').contains( 'Patterns' ).click();
+        cy.get('.edit-post-header-toolbar__inserter-toggle, .editor-document-tools__inserter-toggle').click();
+        cy.get('.components-tab-panel__tabs button, .block-editor-inserter__tabs button').contains( 'Patterns' ).click();
 
         // (add version) If dropdown is available. (After WP 5.?)
         cy.get('body').then(($body) => {


### PR DESCRIPTION
### Description of the Change
The PR proposes upgrading the `download-artifact` to v4. This upgrade is related to the upgrade of `upload-artifact` to v4 in PR https://github.com/10up/action-wordpress-plugin-build-zip/pull/3. Version 4 contains breaking changes, and this PR ensures that everything keeps working after the build zip action updates the `upload-artifact` to v4.

> [!NOTE]
> Please merge this PR after the action https://github.com/marketplace/actions/wordpress-plugin-build-zip gets released.

### How to test the Change
Please ensure that the E2E test action runs successfully after the release of the action available at https://github.com/marketplace/actions/wordpress-plugin-build-zip.

### Changelog Entry
> Changed - Upgrade the `download-artifact` from v3 to v4

### Credits
Props @iamdharmesh

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
