### PR TITLE
Disable auto sync PRs with target branch

### DIFF
--- a/.github/workflows/repo-automator.yml
+++ b/.github/workflows/repo-automator.yml
@@ -25,7 +25,6 @@ jobs:
           fail-label: needs:feedback
           pass-label: needs:code-review
           conflict-label: needs:refresh
-          sync-pr-branch: true
           reviewers: |
             faisal-alvi
             team:open-source-practice


### PR DESCRIPTION
### Description of the Change
PR removes explicitly enabled auto sync PR feature to stop PR syncing. 

**Reason for disabling this:** (until we find a way to handle this better way, want to keep this disabled)
- It keeps sending notifications from PRs for every sync.
- GH action not getting triggered for the sync commit, which makes the unknown status of checks on the latest PR commit.



### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Changed - Disabled auto sync pull requests with target branch.


### Credits
Props @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
