### PR TITLE
Adjust frontend styles to be compatible with latest core themes

### DIFF
--- a/assets/css/frontend/components/tabs.css
+++ b/assets/css/frontend/components/tabs.css
@@ -176,6 +176,11 @@ div.wp-block-group.pmk-tabs-table {
 			text-align: left;
 		}
 
+		& tbody tr:nth-child(even) {
+			background-color: var(--wp--preset--color--base);
+			color: var(--wp--preset--color--contrast);
+		}
+
 		& tbody tr:nth-child(odd) {
 			background-color: var(--pmk-global-color-background-focus);
 			color: var(--pmk-global-color-text-on-background);

--- a/assets/css/frontend/components/why-digital.css
+++ b/assets/css/frontend/components/why-digital.css
@@ -1,14 +1,13 @@
 div.wp-block-group.pmk-why-digital {
 	background-color: var(--pmk-global-color-background-focus);
 	color: var(--pmk-global-color-text-on-background);
-	margin-bottom: var(--pmk-spacing-components);
-	margin-top: 0;
+	margin: var(--pmk-spacing-components) 0;
+	padding: var(--pmk-spacing-related);
 
 	& .wp-block-group__inner-container {
 
 		@mixin has-full-width-background;
 
-		padding: var(--pmk-spacing-components) 0 var(--pmk-spacing-internal-xlarge);
 	}
 
 	& h2 {


### PR DESCRIPTION
### Description of the Change
This PR addresses styling issues found on the latest Core theme and WordPress version in issue #138 

Some of the issues I did not find and others I felt did not need to be addressed.

I tested on Twenty Twenty Four, Twenty Twenty Three, Twenty Twenty Two, and Twenty Twenty on WordPress 6.5

### 1 - Spacing issue on 'Audience Profiles' Section

I did not see this issue and no changes were made.

<img width="1165" alt="image" src="https://github.com/10up/publisher-media-kit/assets/4236538/c38b423e-990c-4029-ae40-480515558949">

### 2 - Spacing issue on 'Why you should choose digital' Section

I adjusted the top margin for this group as well as the interior padding on all four sides. I did not place the headings and icons inline as that can be done with a Row block in the editor.

<img width="1212" alt="image" src="https://github.com/10up/publisher-media-kit/assets/4236538/0f17f08c-6f75-4e4b-9f06-291e32af0aaf">

### 3 - Font is different in all section

The font faces were all correct with what is being loaded on the site. The font sizes and color looked intentional in the stylesheets as well. I did not change anything related to this issue.

<img width="1120" alt="image" src="https://github.com/10up/publisher-media-kit/assets/4236538/3b9c9e66-eeb6-4c69-bd7e-090235057602">

### 4 - Background color is missing in 'Our package' and 'Why you should choose digital' section

Our Packages does not have a background color nor does it have one in the CSS file that is not being targetted properly. I did not change this section.

Why Choose does have a background color and was left as-is. Look at the screenshot above in number 2. It is a very faint background color but it is there.

<img width="1137" alt="image" src="https://github.com/10up/publisher-media-kit/assets/4236538/eda7983c-9e08-48ac-a651-57d2e2890629">


### 5 - Background colour is missing in table block

The even rows in the table do not have a background color or a text color the way odd rows do. Even though the existing styles look good on all tested themes, I went ahead and added a background color and text color based on the core present CSS variables just in case these colors are wildly different than the background color. To the naked eye, nothing looks to have changed.

<img width="1121" alt="image" src="https://github.com/10up/publisher-media-kit/assets/4236538/555095a9-a1d4-48df-a3ae-36bd580138fa">


### 6 - Still Have Questions Background Color

This section does have a background color although it is very faint. I did not change this section.

<img width="1130" alt="image" src="https://github.com/10up/publisher-media-kit/assets/4236538/be36f069-3e3f-4a90-a0d2-2b83c51d04a9">



Closes #183 

### How to test the Change
1. Activate the plugin
2. View the Media Kit page on the frontend
3. Review styles

### Changelog Entry
> Added - Margin to the top of Why Digital Group
> Added - Padding to Why Digital Group
> Added - Background and text color to even table rows

### Credits
Props @claytoncollie


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my change.
- [] All new and existing tests pass.
