### PR TITLE
Exclude the 10up-lib directory from the PHPCS check.

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,5 +5,5 @@
 	<exclude-pattern>dist/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>
 	<exclude-pattern>tests/</exclude-pattern>
-	<exclude-pattern>10up-lib/</exclude-pattern>
+	<exclude-pattern>10up-lib1/</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,4 +5,5 @@
 	<exclude-pattern>dist/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>
 	<exclude-pattern>tests/</exclude-pattern>
+	<exclude-pattern>10up-lib/</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,5 +5,5 @@
 	<exclude-pattern>dist/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>
 	<exclude-pattern>tests/</exclude-pattern>
-	<exclude-pattern>10up-lib1/</exclude-pattern>
+	<exclude-pattern>10up-lib/</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
### Description of the Change
PR excludes the `10up-lib` directory from the PHPCS check to fix the PHPCS GitHub action workflow. `10up-lib` directory contains the https://github.com/10up/wp-compat-validation-tool composer package.

### How to test the Change
- Verify that the `Linting / eslint` GitHub action check is passing.

### Changelog Entry
> Fixed - Ensure that the PHPCS check in the GitHub Action works properly

### Credits
Props @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
