### PR TITLE
Bump the wordpress version to 6.6

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.5'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Twenty Twenty One default theme | Newspack base theme
 ## Requirements
 
 * PHP Requires: 7.4+
-* WordPress Requires at least: 6.5+
+* WordPress Requires at least: 6.6+
 
 ## Theme Compatibility
 

--- a/publisher-media-kit.php
+++ b/publisher-media-kit.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/publisher-media-kit
  * Description:       Pre-configured Media Kit Page using Gutenberg Block Patterns.
  * Version:           1.3.6
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/tests/cypress/integration/pmk-block-patterns.test.js
+++ b/tests/cypress/integration/pmk-block-patterns.test.js
@@ -22,6 +22,8 @@ describe('Check if Media Kit Block Pattern is available for use', () => {
 				});
 			} else if ($body.find('[aria-label="Publisher Media Kit"]').length > 0) {
 				cy.get('[aria-label="Publisher Media Kit"]').click();
+			} else if ($body.find(':contains("Publisher Media Kit")').length > 0) {
+				cy.contains(/^Publisher Media Kit$/).click();
 			}
 
 			// Check if cover patter exist in the list


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #217 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Follow the critical flows to test the PR

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - 
1. Bump WordPress "require at least" version 6.6
2. Bump WordPress "Minimum Require" version 6.6






